### PR TITLE
Use generics to enable Vertex data of any type

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ If you're installing a Linux package, this means you have to ensure that depende
 
 ## Features
 
+- uses generics for Node Data (attach any type of data you like!)
 - checks to make sure all vertex references are valid when adding edges
-- pass in whatever string you want to use for unique vertex Keys
-- supports multiple dependencies (I guess all implementations do this, so I don't know what I'm celebrating)
+- uses strings for vertex keys
+- supports multiple dependencies (I guess all implementations do this, so I don't know what I'm celebrating, but this was the original itch I wanted to scratch)
 
 ## Basic Usage
 
@@ -175,7 +176,6 @@ func topoSortHCL(parsedConfig HCLConfig) ([]string, error) {
 	// this is so we can check for invalid dependencies between configs, which we can't do on the first pass (since we don't yet have a complete set of valid config IDs/names)
 	for _, cfg := range parsedConfig.Configs {
 		// add the config as a vertex
-		// TODO registervertex won't be able to take arbitrary data like RegisterVertex(cfg.Name, cfg) until I add support for generics
 		graph.RegisterVertex(cfg.Name, "dummy")
 
 		// add the config ID (name) to our (incomplete) adjacency list
@@ -230,7 +230,6 @@ Pretty cool!
 
 ## TODOs
 
-- use generics for Node Data (not just strings)
 - smooth out the vertex registration and edge-adding flow -- maybe add a function that takes an adjacency list (or map) and does the uniqueness/presence-checking internally? Like graphWithVertices() in the test suite?
     - add exported functions with friendly names? `AddItem` (== RegisterVertex) and `AddDependency` (== AddEdge)?
 - TODO(dcohen) in a future version, `TopologicalSort()` should return the `graph.topoSortedOrder` (pointers, not string Keys or Data)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you're installing a Linux package, this means you have to ensure that depende
 ## Features
 
 - checks to make sure all vertex references are valid when adding edges
-- pass in whatever string you want to use for unique vertex Names
+- pass in whatever string you want to use for unique vertex Keys
 - supports multiple dependencies (I guess all implementations do this, so I don't know what I'm celebrating)
 
 ## Basic Usage
@@ -26,8 +26,8 @@ import (
 )
 
 func main() {
-	// Create a new graph
-	graph := topologicalsort.NewGraph()
+	// Create a new graph, passing in the type of data we want to use for our nodes
+	graph := topologicalsort.NewGraph("")
 
 	// Register our packages as vertices
 	graph.RegisterVertex("build-essential", "be-data")
@@ -167,7 +167,9 @@ func topoSortHCL(parsedConfig HCLConfig) ([]string, error) {
 	// aspirational / API design
 	// map[string][]string allows each config (uniquely ID'd by a string) to depend on multiple other configs
 	adjacencyList := make(map[string][]string)
-	graph := topologicalsort.NewGraph()
+
+	// Create a new Graph[string] by passing a string to the constructor
+	graph := topologicalsort.NewGraph("")
 
 	// go through the list of parsed configs once, building up an empty adjacency map
 	// this is so we can check for invalid dependencies between configs, which we can't do on the first pass (since we don't yet have a complete set of valid config IDs/names)
@@ -232,4 +234,6 @@ Pretty cool!
 - smooth out the vertex registration and edge-adding flow -- maybe add a function that takes an adjacency list (or map) and does the uniqueness/presence-checking internally? Like graphWithVertices() in the test suite?
     - add exported functions with friendly names? `AddItem` (== RegisterVertex) and `AddDependency` (== AddEdge)?
 - TODO(dcohen) in a future version, `TopologicalSort()` should return the `graph.topoSortedOrder` (pointers, not string Keys or Data)
+- should the graph even keep a toposorted order? Or should that be dynamically generated and immediately returned?
+- does the graph struct make sense? Do we need vertices AND an adjacencylist? I think just the adjacencylist gives us vertices (adjacencylist keys are vertices)
 

--- a/topologicalsort.go
+++ b/topologicalsort.go
@@ -154,17 +154,17 @@ func NewGraphFromData[T any](nodes map[*GraphNode[T]][]string) (*Graph[T], error
 		vertices:        make(map[string]*GraphNode[T]),
 		topoSortedOrder: make([]*GraphNode[T], 0),
 	}
-	// Build up the graph
-	for node, adjacencies := range nodes {
-		// Create a graph vertex
+	// Iterate through vertices to build up the graph
+	for node := range nodes {
 		err = graph.RegisterVertex(node.Key, node.Data)
 		if err != nil {
 			return nil, err
 		}
+	}
 
-		// Add its edges
+	// Add edges between vertices
+	for node, adjacencies := range nodes {
 		for _, a := range adjacencies {
-			fmt.Println(node.Key, "depends on", a)
 			err = graph.AddEdge(node.Key, a)
 			if err != nil {
 				return nil, err

--- a/topologicalsort_test.go
+++ b/topologicalsort_test.go
@@ -1,17 +1,18 @@
 package topologicalsort
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
 
-func graphWithVertices(vertices map[string][]string) *Graph {
-	graph := NewGraph()
+func graphWithVerticesDUMMYDATA[T any](vertices map[string][]string, sampleData T) *Graph[T] {
+	graph := NewGraph(sampleData)
 
 	// Create vertices
 	for k := range vertices {
 		// uses dummy values
-		graph.RegisterVertex(k, "")
+		graph.RegisterVertex(k, sampleData)
 	}
 
 	// add edges
@@ -30,18 +31,21 @@ func TestGraph_TopologicalSort(t *testing.T) {
 		name string
 		// adjacency_list is used to build the test graph -- vertices and all of their dependencies
 		adjacency_list map[string][]string
+		dummyData      any
 		want           []string
 		wantErr        bool
 	}{
 		{
 			name:           "A graph with no vertices is already sorted.",
 			adjacency_list: map[string][]string{},
+			dummyData:      "",
 			want:           []string{},
 			wantErr:        false,
 		},
 		{
 			name:           "A graph with one vertex is already sorted.",
 			adjacency_list: map[string][]string{"sorted": {}},
+			dummyData:      "",
 			want:           []string{"sorted"},
 			wantErr:        false,
 		},
@@ -60,20 +64,22 @@ func TestGraph_TopologicalSort(t *testing.T) {
 				"gcc":             {"libc"},
 				"libc":            {},
 			},
-			want:    []string{"libc", "gcc", "make", "build-essential"},
-			wantErr: false,
+			dummyData: "",
+			want:      []string{"libc", "gcc", "make", "build-essential"},
+			wantErr:   false,
 		},
 		{
 			name: "A graph with no cycles can be sorted.",
 			adjacency_list: map[string][]string{
+				"four":  {"three"},
 				"one":   {},
 				"two":   {"one"},
 				"three": {"two"},
-				"four":  {"three"},
 				"five":  {"four"},
 			},
-			want:    []string{"one", "two", "three", "four", "five"},
-			wantErr: false,
+			dummyData: "",
+			want:      []string{"one", "two", "three", "four", "five"},
+			wantErr:   false,
 		},
 		{
 			name: "A graph with a cycle triggers an error",
@@ -84,14 +90,92 @@ func TestGraph_TopologicalSort(t *testing.T) {
 				"four":  {"three", "two", "one"},
 				"five":  {"four", "three"},
 			},
-			want:    []string{},
-			wantErr: true,
+			dummyData: "",
+			want:      []string{},
+			wantErr:   true,
+		},
+		{
+			name: "Test Generics: a graph using integer data still works",
+			adjacency_list: map[string][]string{
+				"one": {},
+				"two": {"one"},
+			},
+			dummyData: 0,
+			want:      []string{"one", "two"},
+			wantErr:   false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := graphWithVertices(tt.adjacency_list)
+			g := graphWithVerticesDUMMYDATA(tt.adjacency_list, tt.dummyData)
 			got, err := g.TopologicalSort()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Graph.TopologicalSort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Graph.TopologicalSort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_TopographicSort_With_Arbitrary_Data(t *testing.T) {
+	type myTestType struct {
+		floob string
+		burb  int
+	}
+
+	tests := []struct {
+		name       string
+		graph_data map[*GraphNode[myTestType]][]string
+		want       []string
+		wantErr    bool
+	}{
+		{
+			name:       "A graph with no vertices is already sorted.",
+			graph_data: map[*GraphNode[myTestType]][]string{},
+			want:       []string{},
+			wantErr:    false,
+		},
+		{
+			name: "Graph nodes with struct type Data can still be Topographically sorted",
+			graph_data: map[*GraphNode[myTestType]][]string{
+				// node three (intentionally out of order)
+				{
+					Key: "three",
+					Data: myTestType{
+						floob: "dataforthree",
+						burb:  3,
+					},
+				}: {"two"},
+				// node one
+				{
+					Key: "one",
+					Data: myTestType{
+						floob: "dataforone",
+						burb:  1,
+					},
+				}: {},
+				// node two
+				{
+					Key: "two",
+					Data: myTestType{
+						floob: "datafortwo",
+						burb:  2,
+					},
+				}: {"one"},
+			},
+			want:    []string{"one", "two", "three"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGraphFromData(tt.graph_data)
+
+			got, err := g.TopologicalSort()
+			fmt.Println(fmt.Sprintf("%+v", g))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Graph.TopologicalSort() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/topologicalsort_test.go
+++ b/topologicalsort_test.go
@@ -1,7 +1,6 @@
 package topologicalsort
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -95,6 +94,28 @@ func TestGraph_TopologicalSort(t *testing.T) {
 			wantErr:   true,
 		},
 		{
+			name: "Replicate broken arbitrary-data test",
+			adjacency_list: map[string][]string{
+				"three": {"two"},
+				"one":   {""},
+				"two":   {"one"},
+			},
+			dummyData: "",
+			want:      []string{"one", "two", "three"},
+			wantErr:   false,
+		},
+		{
+			name: "Replicate broken arbitrary-data cycle test",
+			adjacency_list: map[string][]string{
+				"three": {"two"},
+				"one":   {"three"},
+				"two":   {"one"},
+			},
+			dummyData: "",
+			want:      []string{},
+			wantErr:   true,
+		},
+		{
 			name: "Test Generics: a graph using integer data still works",
 			adjacency_list: map[string][]string{
 				"one": {},
@@ -156,7 +177,7 @@ func Test_TopographicSort_With_Arbitrary_Data(t *testing.T) {
 						floob: "dataforone",
 						burb:  1,
 					},
-				}: {},
+				}: {"three"},
 				// node two
 				{
 					Key: "two",
@@ -172,10 +193,13 @@ func Test_TopographicSort_With_Arbitrary_Data(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGraphFromData(tt.graph_data)
+			// Create the graph
+			g, err := NewGraphFromData(tt.graph_data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewGraphFromData: expected graph creation to succeed. error=%v", err)
+			}
 
 			got, err := g.TopologicalSort()
-			fmt.Println(fmt.Sprintf("%+v", g))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Graph.TopologicalSort() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/topologicalsort_test.go
+++ b/topologicalsort_test.go
@@ -177,7 +177,7 @@ func Test_TopographicSort_With_Arbitrary_Data(t *testing.T) {
 						floob: "dataforone",
 						burb:  1,
 					},
-				}: {"three"},
+				}: {},
 				// node two
 				{
 					Key: "two",


### PR DESCRIPTION
Graph nodes (vertices) can now contain any data type they like (See examples in the tests).

I've also created `NewGraphFromData()` which allows library users to build up their own graph nodes ahead of time and then create a graph in a single step, if they prefer.